### PR TITLE
Add NodeName::Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ assert_eq!(nodes[0].children[0].value_as_string().unwrap(), "hi");
 - **Braced blocks are parsed as arbitrary Rust code**
 
   ```html
+  <{ let block = "in node name position"; } />
   <div>{ let block = "in node position"; }</div>
   <div { let block="in attribute position" ; } />
   <div key="{" let block="in attribute value position" ; } />

--- a/src/node.rs
+++ b/src/node.rs
@@ -45,7 +45,7 @@ pub struct Node {
 }
 
 impl Node {
-    /// Returns `String` if `name` is `Some`
+    /// Returns `String` if `name` is `Some` and not `NodeName::Block`
     pub fn name_as_string(&self) -> Option<String> {
         match self.name.as_ref() {
             Some(NodeName::Block(_)) => None,
@@ -54,6 +54,7 @@ impl Node {
         }
     }
 
+    /// Returns `ExprBlock` if `name` is `NodeName::Block(Expr::Block)`
     pub fn name_as_block(&self) -> Option<ExprBlock> {
         match self.name.as_ref() {
             Some(NodeName::Block(Expr::Block(expr))) => Some(expr.to_owned()),
@@ -153,7 +154,7 @@ pub enum NodeName {
     /// Name separated by colons, e.g. `<div on:click={foo} />`
     Colon(Punctuated<Ident, Colon>),
 
-    /// Name specified by arbitrary rust code in braced `{}` blocks
+    /// Arbitrary rust code in braced `{}` blocks
     Block(Expr),
 }
 
@@ -192,7 +193,7 @@ impl fmt::Display for NodeName {
                     .map(|ident| ident.to_string())
                     .collect::<Vec<String>>()
                     .join(":"),
-                NodeName::Block(name) => format!("{:#?}", name), // what's the best way to handle this?
+                NodeName::Block(_) => String::from(""),
             }
         )
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -508,6 +508,11 @@ impl Parser {
         } else if input.peek2(Dash) {
             self.node_name_punctuated_ident::<Dash, fn(_) -> Dash, Ident>(input, Dash)
                 .map(|ok| NodeName::Dash(ok))
+        } else if input.peek(Brace) {
+            let fork = &input.fork();
+            let value = self.block_expr(fork)?;
+            input.advance_to(fork);
+            Ok(NodeName::Block(value))
         } else if input.peek(Ident::peek_any) {
             let mut segments = Punctuated::new();
             let ident = Ident::parse_any(input)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -92,6 +92,16 @@ fn test_block_as_tag_name() {
 }
 
 #[test]
+fn test_block_as_tag_name_with_closing_tag() {
+    let tokens = quote! {
+        <{some_logic(block)}>"Test"</{some_logic(block)}>
+    };
+
+    let nodes = parse2(tokens).unwrap();
+    assert_eq!(nodes[0].name_as_block().is_some(), true);
+}
+
+#[test]
 fn test_dashed_attribute_name() {
     let tokens = quote! {
         <div data-foo="bar" />

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -82,6 +82,16 @@ fn test_path_as_tag_name() {
 }
 
 #[test]
+fn test_block_as_tag_name() {
+    let tokens = quote! {
+        <{some_logic(block)} />
+    };
+
+    let nodes = parse2(tokens).unwrap();
+    assert_eq!(nodes[0].name_as_block().is_some(), true);
+}
+
+#[test]
 fn test_dashed_attribute_name() {
     let tokens = quote! {
         <div data-foo="bar" />


### PR DESCRIPTION
It was startling that it was so easy to do this, but it passes tests, and actually works as I was hoping it would work in the library I'm building.

Open question how `NodeName::Block` should `impl Display` but it returns `None` for `.name_as_string()` so maybe it's not a big deal one way or the other.