### PR TITLE
refactor!: switch `Node` to enum-style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ license = "MIT"
 bench = false
 
 [dependencies]
-proc-macro2 = "1.0.40"
-quote = "1.0.20"
-syn = { version = "1.0.98", features = ["full", "parsing", "extra-traits"] }
+proc-macro2 = "1.0.47"
+quote = "1.0.21"
+syn = { version = "1.0.102", features = ["full", "parsing", "extra-traits"] }
+thiserror = "1.0.37"
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.4.0"
+extrude = "0.1.0"
+eyre = "0.6.8"
 
 [[bench]]
 name = "bench"

--- a/examples/html-to-string-macro/Cargo.toml
+++ b/examples/html-to-string-macro/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.36"
-quote = "1.0.15"
-syn = "1.0.86"
-syn-rsx = "0.8.1"
+proc-macro2 = "1.0.47"
+quote = "1.0.21"
+syn = "1.0.102"
+syn-rsx = { path = "../../" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("TryFrom failed: {0}")]
+    TryFrom(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,25 @@
 //! value are syn expressions to support building proc macros.
 //!
 //! ```rust
+//! # fn main() -> eyre::Result<()> {
+//! use std::convert::TryFrom;
+//!
+//! use extrude::extrude;
 //! use quote::quote;
-//! use syn_rsx::parse2;
+//! use syn_rsx::{parse2, Node, NodeAttribute, NodeElement, NodeText};
 //!
 //! let tokens = quote! { <hello world>"hi"</hello> };
+//! let nodes = parse2(tokens)?;
 //!
-//! let nodes = parse2(tokens).unwrap();
-//! assert_eq!(nodes[0].name_as_string().unwrap(), "hello");
-//! assert_eq!(nodes[0].attributes[0].name_as_string().unwrap(), "world");
-//! assert_eq!(nodes[0].children[0].value_as_string().unwrap(), "hi");
+//! let element = extrude!(&nodes[0], Node::Element(element)).unwrap();
+//! let attribute = extrude!(&element.attributes[0], Node::Attribute(attribute)).unwrap();
+//! let text = extrude!(&element.children[0], Node::Text(text)).unwrap();
+//!
+//! assert_eq!(element.name.to_string(), "hello");
+//! assert_eq!(attribute.key.to_string(), "world");
+//! assert_eq!(String::try_from(&text.value)?, "hi");
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Features
@@ -137,6 +147,7 @@ use syn::{
 };
 
 mod config;
+mod error;
 mod node;
 mod parser;
 
@@ -148,7 +159,8 @@ pub mod punctuation {
 }
 
 pub use config::ParserConfig;
-pub use node::{Node, NodeName, NodeType};
+pub use error::Error;
+pub use node::*;
 pub use parser::Parser;
 
 /// Parse the given [`proc-macro::TokenStream`] into a [`Node`] tree

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,124 +1,25 @@
-//! Tree of nodes
+//! Tree of nodes.
 
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
-use std::fmt;
+use std::{convert::TryFrom, fmt, ops::Deref};
 use syn::{
-    punctuated::Punctuated, spanned::Spanned, token::Colon, Expr, ExprBlock, ExprPath, Ident, Lit,
+    punctuated::Punctuated, spanned::Spanned, token::Colon, Expr, ExprBlock, ExprLit, ExprPath,
+    Ident, Lit,
 };
 
-use crate::punctuation::Dash;
+use crate::{punctuation::Dash, Error};
 
-/// Node in the tree
-#[derive(Debug)]
-pub struct Node {
-    /// Name according to the `NodeType`
-    ///
-    /// - Element: Name of the element
-    /// - Attribute: Key of the element attribute
-    /// - Text: `None`
-    /// - Doctype: `None`
-    /// - Comment: `None`
-    /// - Fragment: `None`
-    /// - Block: `None`
-    pub name: Option<NodeName>,
-
-    /// Type of the node
-    pub node_type: NodeType,
-
-    /// Value according to the `NodeType`
-    ///
-    /// - Element: `None`
-    /// - Attribute: Any valid `syn::Expr`
-    /// - Text: `syn::Expr::Lit`
-    /// - Doctype: `syn::Expr::Lit`
-    /// - Comment: `syn::Expr::Lit`
-    /// - Fragment: `None`
-    /// - Block: `syn::Expr::Block`
-    pub value: Option<Expr>,
-
-    /// `NodeType::Element` attributes are `NodeType::Attribute` or `NodeType::Block`
-    pub attributes: Vec<Node>,
-
-    /// `NodeType::Element` children can be everything except `NodeType::Attribute`
-    pub children: Vec<Node>,
-}
-
-impl Node {
-    /// Returns `String` if `name` is `Some` and not `NodeName::Block`
-    pub fn name_as_string(&self) -> Option<String> {
-        match self.name.as_ref() {
-            Some(NodeName::Block(_)) => None,
-            Some(name) => Some(name.to_string()),
-            None => None,
-        }
-    }
-
-    /// Returns `ExprBlock` if `name` is `NodeName::Block(Expr::Block)`
-    pub fn name_as_block(&self) -> Option<ExprBlock> {
-        match self.name.as_ref() {
-            Some(NodeName::Block(Expr::Block(expr))) => Some(expr.to_owned()),
-            _ => None,
-        }
-    }
-
-    /// Returns `Span` if `name` is `Some`
-    pub fn name_span(&self) -> Option<Span> {
-        self.name.as_ref().map(|name| name.span())
-    }
-
-    /// Returns `String` if `value` is a `Lit` or `Path` expression
-    pub fn value_as_string(&self) -> Option<String> {
-        match self.value.as_ref() {
-            Some(Expr::Lit(expr)) => match &expr.lit {
-                Lit::Str(lit_str) => Some(lit_str.value()),
-                _ => None,
-            },
-            Some(Expr::Path(expr)) => Some(path_to_string(expr)),
-            _ => None,
-        }
-    }
-
-    /// Returns `ExprBlock` if `value` is a `Expr::Block` expression
-    pub fn value_as_block(&self) -> Option<ExprBlock> {
-        match self.value.as_ref() {
-            Some(Expr::Block(expr)) => Some(expr.to_owned()),
-            _ => None,
-        }
-    }
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
-/// Type of the node
-#[derive(Debug, Clone, PartialEq)]
+/// Node types.
+#[derive(Debug, PartialEq, Eq)]
 pub enum NodeType {
-    /// A HTMLElement tag, with optional children and attributes.
-    /// Potentially selfclosing. Any tag name is valid.
     Element,
-
-    /// Attributes of opening tags. Every attribute is itself a node.
     Attribute,
-
-    /// Quoted text. It's [planned to support unquoted text] as well
-    /// using span start and end, but that currently only works
-    /// with nightly rust
-    ///
-    /// [planned to support unquoted text]: https://github.com/stoically/syn-rsx/issues/2
     Text,
-
-    /// Comment: `<!-- "comment" -->`, currently has the same restrictions as
-    /// `Text` (comment needs to be quoted)
     Comment,
-
-    /// Doctype declaration: `<!DOCTYPE html>` (case insensitive), `html` is the
-    /// node value in this case
     Doctype,
-
-    /// Fragment: `<></>`
-    Fragment,
-
-    /// Arbitrary rust code in braced `{}` blocks
     Block,
+    Fragment,
 }
 
 impl fmt::Display for NodeType {
@@ -132,10 +33,191 @@ impl fmt::Display for NodeType {
                 Self::Text => "NodeType::Text",
                 Self::Comment => "NodeType::Comment",
                 Self::Doctype => "NodeType::Doctype",
-                Self::Fragment => "NodeType::Fragment",
                 Self::Block => "NodeType::Block",
+                Self::Fragment => "NodeType::Fragment",
             }
         )
+    }
+}
+
+/// Node in the tree.
+#[derive(Debug)]
+pub enum Node {
+    Element(NodeElement),
+    Attribute(NodeAttribute),
+    Text(NodeText),
+    Comment(NodeComment),
+    Doctype(NodeDoctype),
+    Block(NodeBlock),
+    Fragment(NodeFragment),
+}
+
+impl Node {
+    /// Get the type of the node.
+    pub fn r#type(&self) -> NodeType {
+        match &self {
+            Self::Element(_) => NodeType::Element,
+            Self::Attribute(_) => NodeType::Attribute,
+            Self::Text(_) => NodeType::Text,
+            Self::Comment(_) => NodeType::Comment,
+            Self::Doctype(_) => NodeType::Element,
+            Self::Block(_) => NodeType::Block,
+            Self::Fragment(_) => NodeType::Fragment,
+        }
+    }
+
+    /// Get node children.
+    pub fn children(&self) -> Option<&Vec<Node>> {
+        match self {
+            Self::Fragment(NodeFragment { children })
+            | Self::Element(NodeElement { children, .. }) => Some(children),
+            _ => None,
+        }
+    }
+
+    /// Get mutable node children.
+    pub fn children_mut(&mut self) -> Option<&mut Vec<Node>> {
+        match self {
+            Self::Fragment(NodeFragment { children })
+            | Self::Element(NodeElement { children, .. }) => Some(children),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Element(_) => "Node::Element",
+                Self::Attribute(_) => "Node::Attribute",
+                Self::Text(_) => "Node::Text",
+                Self::Comment(_) => "Node::Comment",
+                Self::Doctype(_) => "Node::Doctype",
+                Self::Block(_) => "Node::Block",
+                Self::Fragment(_) => "Node::Fragment",
+            }
+        )
+    }
+}
+
+/// Element node.
+///
+/// A HTMLElement tag, with optional children and attributes.
+/// Potentially selfclosing. Any tag name is valid.
+#[derive(Debug)]
+pub struct NodeElement {
+    /// Name of the element.
+    pub name: NodeName,
+    /// Attributes of the element node.
+    pub attributes: Vec<Node>,
+    /// Children of the element node.
+    pub children: Vec<Node>,
+}
+
+impl fmt::Display for NodeElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeElement")
+    }
+}
+
+/// Attribute node.
+///
+/// Attributes of opening tags. Every attribute is itself a node.
+#[derive(Debug)]
+pub struct NodeAttribute {
+    /// Key of the element attribute.
+    pub key: NodeName,
+    /// Value of the element attribute.
+    pub value: Option<NodeValueExpr>,
+}
+
+impl fmt::Display for NodeAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeAttribute")
+    }
+}
+
+/// Text node.
+///
+/// Quoted text. It's [planned to support unquoted text] as well
+/// using span start and end, but that currently only works
+/// with nightly rust.
+///
+/// [planned to support unquoted text]: https://github.com/stoically/syn-rsx/issues/2
+#[derive(Debug)]
+pub struct NodeText {
+    /// The text value.
+    pub value: NodeValueExpr,
+}
+
+impl fmt::Display for NodeText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeText")
+    }
+}
+
+/// Comment node.
+///
+/// Comment: `<!-- "comment" -->`, currently has the same restrictions as
+/// `Text` (comment needs to be quoted).
+#[derive(Debug)]
+pub struct NodeComment {
+    /// The comment value.
+    pub value: NodeValueExpr,
+}
+
+impl fmt::Display for NodeComment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeComment")
+    }
+}
+
+/// Doctype node.
+///
+/// Doctype declaration: `<!DOCTYPE html>` (case insensitive), `html` is the
+/// node value in this case.
+#[derive(Debug)]
+pub struct NodeDoctype {
+    /// The doctype value.
+    pub value: NodeValueExpr,
+}
+
+impl fmt::Display for NodeDoctype {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeDoctype")
+    }
+}
+
+/// Fragement node.
+///
+/// Fragment: `<></>`
+#[derive(Debug)]
+pub struct NodeFragment {
+    /// Children of the fragment node.
+    pub children: Vec<Node>,
+}
+
+impl fmt::Display for NodeFragment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeFragment")
+    }
+}
+
+/// Block node.
+///
+/// Arbitrary rust code in braced `{}` blocks.
+#[derive(Debug)]
+pub struct NodeBlock {
+    /// The block value..
+    pub value: NodeValueExpr,
+}
+
+impl fmt::Display for NodeBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeBlock")
     }
 }
 
@@ -143,21 +225,21 @@ impl fmt::Display for NodeType {
 #[derive(Debug)]
 pub enum NodeName {
     /// A plain identifier like `div` is a path of length 1, e.g. `<div />`. Can
-    /// be separated by double colons, e.g. `<foo::bar />`
+    /// be separated by double colons, e.g. `<foo::bar />`.
     Path(ExprPath),
 
-    /// Name separated by dashes, e.g. `<div data-foo="bar" />`
+    /// Name separated by dashes, e.g. `<div data-foo="bar" />`.
     Dash(Punctuated<Ident, Dash>),
 
-    /// Name separated by colons, e.g. `<div on:click={foo} />`
+    /// Name separated by colons, e.g. `<div on:click={foo} />`.
     Colon(Punctuated<Ident, Colon>),
 
-    /// Arbitrary rust code in braced `{}` blocks
+    /// Arbitrary rust code in braced `{}` blocks.
     Block(Expr),
 }
 
 impl NodeName {
-    /// Returns the `Span` of this `NodeName`
+    /// Returns the `Span` of this `NodeName`.
     pub fn span(&self) -> Span {
         match self {
             NodeName::Path(name) => name.span(),
@@ -168,26 +250,16 @@ impl NodeName {
     }
 }
 
-impl fmt::Display for NodeName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                NodeName::Path(expr) => path_to_string(expr),
-                NodeName::Dash(name) => name
-                    .iter()
-                    .map(|ident| ident.to_string())
-                    .collect::<Vec<String>>()
-                    .join("-"),
-                NodeName::Colon(name) => name
-                    .iter()
-                    .map(|ident| ident.to_string())
-                    .collect::<Vec<String>>()
-                    .join(":"),
-                NodeName::Block(_) => String::from("{}"),
-            }
-        )
+impl TryFrom<&NodeName> for ExprBlock {
+    type Error = Error;
+
+    fn try_from(node: &NodeName) -> Result<Self, Self::Error> {
+        match node {
+            NodeName::Block(Expr::Block(expr)) => Ok(expr.to_owned()),
+            _ => Err(Error::TryFrom(
+                "NodeName does not match NodeName::Block(Expr::Block(_))".into(),
+            )),
+        }
     }
 }
 
@@ -225,7 +297,135 @@ impl ToTokens for NodeName {
     }
 }
 
-fn path_to_string(expr: &ExprPath) -> String {
+impl fmt::Display for NodeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                NodeName::Path(expr) => path_to_string(expr),
+                NodeName::Dash(name) => name
+                    .iter()
+                    .map(|ident| ident.to_string())
+                    .collect::<Vec<String>>()
+                    .join("-"),
+                NodeName::Colon(name) => name
+                    .iter()
+                    .map(|ident| ident.to_string())
+                    .collect::<Vec<String>>()
+                    .join(":"),
+                NodeName::Block(_) => String::from("{}"),
+            }
+        )
+    }
+}
+
+/// Smart pointer to `syn::Expr`.
+#[derive(Debug)]
+pub struct NodeValueExpr {
+    expr: Expr,
+}
+
+impl NodeValueExpr {
+    /// Create a `NodeValueExpr`.
+    pub fn new(expr: Expr) -> Self {
+        Self { expr }
+    }
+}
+
+impl AsRef<Expr> for NodeValueExpr {
+    fn as_ref(&self) -> &Expr {
+        &self.expr
+    }
+}
+
+impl Deref for NodeValueExpr {
+    type Target = Expr;
+
+    fn deref(&self) -> &Self::Target {
+        &self.expr
+    }
+}
+
+impl From<Expr> for NodeValueExpr {
+    fn from(expr: Expr) -> Self {
+        Self { expr }
+    }
+}
+
+impl From<ExprLit> for NodeValueExpr {
+    fn from(expr: ExprLit) -> Self {
+        Self { expr: expr.into() }
+    }
+}
+
+impl From<ExprBlock> for NodeValueExpr {
+    fn from(expr: ExprBlock) -> Self {
+        Self { expr: expr.into() }
+    }
+}
+
+impl From<NodeValueExpr> for Expr {
+    fn from(value: NodeValueExpr) -> Self {
+        value.expr
+    }
+}
+
+impl<'a> From<&'a NodeValueExpr> for &'a Expr {
+    fn from(value: &'a NodeValueExpr) -> Self {
+        &value.expr
+    }
+}
+
+impl TryFrom<NodeValueExpr> for ExprBlock {
+    type Error = Error;
+
+    fn try_from(value: NodeValueExpr) -> Result<Self, Self::Error> {
+        if let Expr::Block(block) = value.expr {
+            Ok(block)
+        } else {
+            Err(Error::TryFrom(
+                "NodeValueExpr does not match Expr::Block(_)".into(),
+            ))
+        }
+    }
+}
+
+impl TryFrom<NodeValueExpr> for ExprLit {
+    type Error = Error;
+
+    fn try_from(value: NodeValueExpr) -> Result<Self, Self::Error> {
+        if let Expr::Lit(lit) = value.expr {
+            Ok(lit)
+        } else {
+            Err(Error::TryFrom(
+                "NodeValueExpr does not match Expr::Lit(_)".into(),
+            ))
+        }
+    }
+}
+
+impl TryFrom<&NodeValueExpr> for String {
+    type Error = Error;
+
+    fn try_from(value: &NodeValueExpr) -> Result<Self, Self::Error> {
+        match &value.expr {
+            Expr::Lit(expr) => match &expr.lit {
+                Lit::Str(lit_str) => Some(lit_str.value()),
+                _ => None,
+            },
+            Expr::Path(expr) => Some(path_to_string(&expr)),
+            _ => None,
+        }
+        .ok_or_else(|| {
+            Error::TryFrom(
+                "NodeValueExpr does not match Expr::Lit(Lit::Str(_)) or Expr::Path(_)".into(),
+            )
+        })
+    }
+}
+
+pub fn path_to_string(expr: &ExprPath) -> String {
     expr.path
         .segments
         .iter()


### PR DESCRIPTION
**Goals**
- Avoid that consumers have to manually check the documentation in order to know when it is safe to `unwrap` node names/values
- Make the API feel more rusty

**Notes**
- Decided against the `NodeElementAttribute` / `NodeElementChild` enums as it would complicate the API significantly
- The price for less complicated node name/value unwrapping – and hence more type safety – is a slightly harder to use API, but well worth it

**Remaining work**
- [x] Add `TryInto<T>` implementations on node types to get a specific syn expression for node values, such as `TryInto<Expr::Lit> for NodeText`
- [x] Fix tests

Feedback welcome.

Resolves https://github.com/stoically/syn-rsx/issues/16, Resolves https://github.com/stoically/syn-rsx/issues/15