### PR TITLE
Allow node names with mixed colons and dashes

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -171,6 +171,20 @@ fn test_coloned_attribute_name() -> Result<()> {
 }
 
 #[test]
+fn test_mixed_colon_and_dash_attribute_name() -> Result<()> {
+    let tokens = quote! {
+        <div on:ce-click={foo} />
+    };
+
+    let nodes = parse2(tokens)?;
+    let attribute = get_element_attribute(&nodes, 0, 0);
+
+    assert_eq!(attribute.key.to_string(), "on:ce-click");
+
+    Ok(())
+}
+
+#[test]
 fn test_block_as_attribute() -> Result<()> {
     let tokens = quote! {
         <div {attribute} />


### PR DESCRIPTION
This is a somewhat stupid attempt, but tests pass. It just merges the `Colon` and `Dash` variants, and then checks for either a `Colon` or `Dash` when it peeks, rather than passing in an allow-list or doing something more generic. I don't think any other punctuation actually ever needs to be included here, so maybe it's fine.

Fixes https://github.com/stoically/syn-rsx/issues/33