### PR TITLE
Give access to closing tag in NodeElement

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -137,7 +137,7 @@ pub struct NodeElement {
     /// enough" approximation in stable until [Span::join] is stabilized.
     pub span: Span,
     /// Closing tag for the element, if it exists.
-    pub closing_tag: Option<NodeName>
+    pub closing_tag: Option<NodeName>,
 }
 
 impl fmt::Display for NodeElement {

--- a/src/node.rs
+++ b/src/node.rs
@@ -136,6 +136,8 @@ pub struct NodeElement {
     /// Note: This should cover the entire node in nightly, but is a "close
     /// enough" approximation in stable until [Span::join] is stabilized.
     pub span: Span,
+    /// Closing tag for the element, if it exists.
+    pub closing_tag: Option<NodeName>
 }
 
 impl fmt::Display for NodeElement {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -213,7 +213,7 @@ impl Parser {
             attributes,
             children,
             span,
-            closing_tag
+            closing_tag,
         }))
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -192,6 +192,7 @@ impl Parser {
         let (name, attributes, self_closing, mut span) = self.tag_open(fork)?;
 
         let mut children = vec![];
+        let mut closing_tag = None;
         if !self_closing {
             loop {
                 if !self.element_has_children(&name, fork)? {
@@ -201,8 +202,9 @@ impl Parser {
                 children.append(&mut self.node(fork)?);
             }
 
-            let (_, closing_span) = self.tag_close(fork)?;
+            let (closing, closing_span) = self.tag_close(fork)?;
             span = span.join(closing_span).unwrap_or(span);
+            closing_tag = Some(closing);
         };
 
         input.advance_to(fork);
@@ -211,6 +213,7 @@ impl Parser {
             attributes,
             children,
             span,
+            closing_tag
         }))
     }
 


### PR DESCRIPTION
See issue #51.

I'm going to leave this as a draft for a minute because I haven't tested whether it's actually what I need for my purpose, but wanted to get feedback. It looks like the parser already had everything it needs here; this just saves exposes the closing `NodeName` instead of throwing it away.